### PR TITLE
Change references of dougcourt.gov to dougtone.com

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,4 +1,4 @@
-<html><head><base href="https://dougcourt.gov/"/>
+<html><head><base href="https://dougtone.com/"/>
 <title>About | The Grand Judiciary of Doug</title>
 <style>
 :root {
@@ -293,12 +293,12 @@ footer {
 
 <nav>
   <ul>
-    <li><a href="https://dougcourt.gov/about">About</a></li>
-    <li><a href="https://dougcourt.gov/opinions">Opinions</a></li>
-    <li><a href="https://dougcourt.gov/oral-arguments">Oral Arguments</a></li>
-    <li><a href="https://dougcourt.gov/rules">Rules & Guidance</a></li>
-    <li><a href="https://dougcourt.gov/forms">Forms</a></li>
-    <li><a href="https://dougcourt.gov/library">Library</a></li>
+    <li><a href="https://dougtone.com/about">About</a></li>
+    <li><a href="https://dougtone.com/opinions">Opinions</a></li>
+    <li><a href="https://dougtone.com/oral-arguments">Oral Arguments</a></li>
+    <li><a href="https://dougtone.com/rules">Rules & Guidance</a></li>
+    <li><a href="https://dougtone.com/forms">Forms</a></li>
+    <li><a href="https://dougtone.com/library">Library</a></li>
   </ul>
 </nav>
 

--- a/docket/index.html
+++ b/docket/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Interactive Docket System | GRAND JUDICIARY OF DOUG</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="https://dougtone.com/styles.css">
 </head>
 <body>
     <header class="header">
@@ -13,16 +13,16 @@
 
     <nav class="nav">
         <ul class="nav-list">
-            <li><a href="../index.html">Home</a></li>
-            <li><a href="../about.html">About</a></li>
-            <li><a href="../meetdoug.html">Meet Doug</a></li>
-            <li><a href="../opinions.html">Opinions</a></li>
-            <li><a href="../dougprocess.html">Doug Process</a></li>
-            <li><a href="../forms.html">Forms</a></li>
-            <li><a href="../library.html">Law Library</a></li>
-            <li><a href="../dougmarshal.html">Office of the Dougmarshal General</a></li>
-            <li><a href="../inquisitor.html">Office of the Presiding Inquisitor</a></li>
-            <li><a href="../archive/admin/index.html">Admin System</a></li>
+            <li><a href="https://dougtone.com/index.html">Home</a></li>
+            <li><a href="https://dougtone.com/about.html">About</a></li>
+            <li><a href="https://dougtone.com/meetdoug.html">Meet Doug</a></li>
+            <li><a href="https://dougtone.com/opinions.html">Opinions</a></li>
+            <li><a href="https://dougtone.com/dougprocess.html">Doug Process</a></li>
+            <li><a href="https://dougtone.com/forms.html">Forms</a></li>
+            <li><a href="https://dougtone.com/library.html">Law Library</a></li>
+            <li><a href="https://dougtone.com/dougmarshal.html">Office of the Dougmarshal General</a></li>
+            <li><a href="https://dougtone.com/inquisitor.html">Office of the Presiding Inquisitor</a></li>
+            <li><a href="https://dougtone.com/archive/admin/index.html">Admin System</a></li>
         </ul>
     </nav>
 
@@ -88,6 +88,6 @@
         </section>
     </main>
 
-    <script src="scripts.js"></script>
+    <script src="https://dougtone.com/scripts.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<html><head><base href="https://dougcourt.gov/"/>
+<html><head><base href="https://dougtone.com/"/>
 <title>The Grand Judiciary of Doug | Official Website</title>
 <style>
 :root {
@@ -170,12 +170,12 @@ footer {
 
 <nav>
   <ul>
-    <li><a href="https://dougcourt.gov/about">About</a></li>
-    <li><a href="https://dougcourt.gov/opinions">Opinions</a></li>
-    <li><a href="https://dougcourt.gov/oral-arguments">Oral Arguments</a></li>
-    <li><a href="https://dougcourt.gov/rules">Rules & Guidance</a></li>
-    <li><a href="https://dougcourt.gov/forms">Forms</a></li>
-    <li><a href="https://dougcourt.gov/library">Library</a></li>
+    <li><a href="https://dougtone.com/about">About</a></li>
+    <li><a href="https://dougtone.com/opinions">Opinions</a></li>
+    <li><a href="https://dougtone.com/oral-arguments">Oral Arguments</a></li>
+    <li><a href="https://dougtone.com/rules">Rules & Guidance</a></li>
+    <li><a href="https://dougtone.com/forms">Forms</a></li>
+    <li><a href="https://dougtone.com/library">Library</a></li>
   </ul>
 </nav>
 

--- a/opinions.html
+++ b/opinions.html
@@ -1,4 +1,4 @@
-<html><head><base href="https://dougcourt.gov/"/>
+<html><head><base href="https://dougtone.com/"/>
 <title>Current Term Opinions - The Grand Judiciary of Doug</title>
 <style>
 :root {
@@ -197,12 +197,12 @@ footer {
 
 <nav>
   <ul>
-    <li><a href="https://dougcourt.gov/about">About</a></li>
-    <li><a href="https://dougcourt.gov/opinions">Opinions</a></li>
-    <li><a href="https://dougcourt.gov/oral-arguments">Oral Arguments</a></li>
-    <li><a href="https://dougcourt.gov/rules">Rules & Guidance</a></li>
-    <li><a href="https://dougcourt.gov/forms">Forms</a></li>
-    <li><a href="https://dougcourt.gov/library">Library</a></li>
+    <li><a href="https://dougtone.com/about">About</a></li>
+    <li><a href="https://dougtone.com/opinions">Opinions</a></li>
+    <li><a href="https://dougtone.com/oral-arguments">Oral Arguments</a></li>
+    <li><a href="https://dougtone.com/rules">Rules & Guidance</a></li>
+    <li><a href="https://dougtone.com/forms">Forms</a></li>
+    <li><a href="https://dougtone.com/library">Library</a></li>
   </ul>
 </nav>
 

--- a/oral-arguments.html
+++ b/oral-arguments.html
@@ -1,4 +1,4 @@
-<html><head><base href="https://dougcourt.gov/"/>
+<html><head><base href="https://dougtone.com/"/>
 <title>Oral Arguments - The Grand Judiciary of Doug</title>
 <style>
 :root {
@@ -161,12 +161,12 @@ footer {
 
 <nav>
   <ul>
-    <li><a href="https://dougcourt.gov/about">About</a></li>
-    <li><a href="https://dougcourt.gov/opinions">Opinions</a></li>
-    <li><a href="https://dougcourt.gov/oral-arguments">Oral Arguments</a></li>
-    <li><a href="https://dougcourt.gov/rules">Rules & Guidance</a></li>
-    <li><a href="https://dougcourt.gov/forms">Forms</a></li>
-    <li><a href="https://dougcourt.gov/library">Library</a></li>
+    <li><a href="https://dougtone.com/about">About</a></li>
+    <li><a href="https://dougtone.com/opinions">Opinions</a></li>
+    <li><a href="https://dougtone.com/oral-arguments">Oral Arguments</a></li>
+    <li><a href="https://dougtone.com/rules">Rules & Guidance</a></li>
+    <li><a href="https://dougtone.com/forms">Forms</a></li>
+    <li><a href="https://dougtone.com/library">Library</a></li>
   </ul>
 </nav>
 


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Dougtone-Tabulator-Division/INTERNET/pull/5?shareId=9e3105cc-8815-42d2-a9fb-6e9ab90b3549).